### PR TITLE
Add a basic benchmark to an integration test suite

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -10,6 +10,18 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: '16'
+          java-version: '17'
       - name: Run checks
         run: ./gradlew clean check --rerun-tasks
+  integration-tests:
+    name: Run integration tests
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+      - name: Run checks
+        run: ./gradlew clean integrationTest --rerun-tasks -Dbenchmark.requests.total=100000

--- a/.run/All unit tests.run.xml
+++ b/.run/All unit tests.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All unit tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="test --tests &quot;*&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list />
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Just integration tests.run.xml
+++ b/.run/Just integration tests.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Just integration tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="integrationTest --tests &quot;*&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list />
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/demo/src/test/kotlin/dev/skye/pellet/DemoSenseCheckTest.kt
+++ b/demo/src/test/kotlin/dev/skye/pellet/DemoSenseCheckTest.kt
@@ -4,10 +4,10 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class SanityTest {
+class DemoSenseCheckTest {
 
     @Test
-    fun `sanity test`() {
+    fun `sense check demo tests`() {
         assertTrue(true)
         assertFalse(false)
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/src/integrationTest/kotlin/dev/skye/pellet/integration/IntegrationSenseCheckTest.kt
+++ b/lib/src/integrationTest/kotlin/dev/skye/pellet/integration/IntegrationSenseCheckTest.kt
@@ -1,13 +1,13 @@
-package dev.skye.pellet
+package dev.skye.pellet.integration
 
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class SenseCheckTest {
+class IntegrationSenseCheckTest {
 
     @Test
-    fun `sense check lib tests`() {
+    fun `sense check integration tests`() {
         assertTrue(true)
         assertFalse(false)
     }

--- a/lib/src/integrationTest/kotlin/dev/skye/pellet/integration/NoContentBenchmarkTest.kt
+++ b/lib/src/integrationTest/kotlin/dev/skye/pellet/integration/NoContentBenchmarkTest.kt
@@ -1,0 +1,123 @@
+package dev.skye.pellet.integration
+
+import dev.skye.pellet.PelletConnector
+import dev.skye.pellet.PelletServer
+import dev.skye.pellet.logging.logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.ConnectionPool
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+
+class NoContentBenchmarkTest {
+
+    private val logger = logger<NoContentBenchmarkTest>()
+    private val numberOfRequests = System.getProperty("benchmark.requests.total")?.toIntOrNull() ?: 1_000_000
+
+    @Test
+    fun `benchmark no content response`() = runBlocking {
+        val connector = PelletConnector.HTTP(
+            hostname = "127.0.0.1",
+            port = 9001
+        )
+        val pellet = PelletServer(listOf(connector))
+        val counter = AtomicInteger(numberOfRequests)
+        val job = pellet.start { _, responder ->
+            counter.decrementAndGet()
+            responder.writeNoContent()
+        }
+
+        val client = OkHttpClient().newBuilder()
+            .connectionPool(ConnectionPool(50, 1L, TimeUnit.MINUTES))
+            .build()
+        client.dispatcher.maxRequestsPerHost = 50
+        client.connectionPool.connectionCount()
+        logger.info("sending ${counter.get()} requests...")
+
+        val processors = Runtime.getRuntime().availableProcessors().coerceAtLeast(2)
+        val dispatcher = Dispatchers.IO.limitedParallelism(processors)
+
+        val channel = Channel<Request>()
+        val supervisor = SupervisorJob()
+        val scope = CoroutineScope(dispatcher + supervisor)
+        scope.launch {
+            numberOfRequests.downTo(0).map {
+                val request = Request.Builder()
+                    .url("http://127.0.0.1:9001")
+                    .get()
+                    .build()
+                channel.send(request)
+            }
+        }
+
+        val startTime = Instant.now()
+        processors.downTo(0).map {
+            scope.async {
+                sendRequests(client, channel)
+            }
+        }
+
+        scope.async {
+            while (this.isActive) {
+                val count = counter.get()
+                if (count <= 0) {
+                    supervisor.cancel()
+                    return@async
+                }
+                logger.info("completed $count")
+                delay(1000L)
+            }
+        }.join()
+        job.cancel()
+
+        val endTime = Instant.now()
+        val timeElapsedMs = Duration.between(startTime, endTime).toMillis()
+        val rps = (numberOfRequests / timeElapsedMs.toDouble()) * 1000L
+        logger.info("completed rps: $rps")
+    }
+
+    private suspend fun CoroutineScope.sendRequests(
+        client: OkHttpClient,
+        channel: Channel<Request>
+    ) {
+        while (this.isActive) {
+            val request = channel.receive()
+            val future = CompletableFuture<Response>()
+            client.newCall(request).enqueue(toCallback(future))
+            val response = future.await()
+            assert(response.code == 204)
+            yield()
+        }
+    }
+
+    private fun toCallback(future: CompletableFuture<Response>): Callback {
+        return object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                future.completeExceptionally(e)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                future.complete(response)
+            }
+        }
+    }
+}

--- a/lib/src/main/kotlin/dev/skye/pellet/PelletServer.kt
+++ b/lib/src/main/kotlin/dev/skye/pellet/PelletServer.kt
@@ -5,10 +5,9 @@ import dev.skye.pellet.codec.http.HTTPRequestHandler
 import dev.skye.pellet.connector.SocketConnector
 import dev.skye.pellet.logging.logger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.scheduling.ExperimentalCoroutineDispatcher
 import java.net.InetSocketAddress
 import kotlin.coroutines.CoroutineContext
 
@@ -30,9 +29,7 @@ class PelletServer(
         logger.info("Please support development at https://www.pellet.dev/support")
 
         val processors = Runtime.getRuntime().availableProcessors().coerceAtLeast(2)
-
-        @OptIn(InternalCoroutinesApi::class)
-        val dispatcher = ExperimentalCoroutineDispatcher().limited(processors)
+        val dispatcher = Dispatchers.IO.limitedParallelism(processors)
         val context = SupervisorJob()
         val scope = object : CoroutineScope {
             override val coroutineContext: CoroutineContext


### PR DESCRIPTION
The reported RPS will be severely limited by GitHub Actions, but it's good to run the benchmark with a limited request total as an additional check on CI.